### PR TITLE
Add Lean as a built-in language

### DIFF
--- a/src/languages.rs
+++ b/src/languages.rs
@@ -8,6 +8,7 @@ pub enum Language {
     Rust,
     OCaml,
     Python,
+    Lean,
     #[serde(untagged)]
     Custom(CustomLanguage),
 }
@@ -30,6 +31,7 @@ impl Language {
             Language::Rust => "rs",
             Language::OCaml => "ml",
             Language::Python => "py",
+            Language::Lean => "lean",
             Language::Custom(custom) => custom.extension.as_str(),
         }
     }
@@ -45,6 +47,7 @@ impl Language {
             "rs" => Some(Language::Rust),
             "ml" => Some(Language::OCaml),
             "py" => Some(Language::Python),
+            "lean" => Some(Language::Lean),
             _ => {
                 for custom in custom_languages {
                     if custom.extension == ext {
@@ -67,6 +70,7 @@ impl Language {
             "rust" => Some(Language::Rust),
             "ocaml" => Some(Language::OCaml),
             "python" => Some(Language::Python),
+            "lean" => Some(Language::Lean),
             _ => {
                 for custom in custom_languages {
                     if custom.name == name {
@@ -87,6 +91,7 @@ impl Language {
             Language::Rust => "/*".to_string(),
             Language::OCaml => "(*".to_string(),
             Language::Python => r#"""""#.to_string(),
+            Language::Lean => "/-".to_string(),
             Language::Custom(custom) => custom.comment_begin.clone(),
         }
     }
@@ -100,6 +105,7 @@ impl Language {
             Language::OCaml => "*)".to_string(),
             Language::Custom(custom) => custom.comment_end.clone(),
             Language::Python => r#"""""#.to_string(),
+            Language::Lean => "-/".to_string(),
         }
     }
 
@@ -150,7 +156,7 @@ impl Language {
             | Language::Racket
             | Language::OCaml
             | Language::Python => "!",
-            Language::Rust => "|",
+            Language::Rust | Language::Lean => "|",
             Language::Custom(custom_language) => custom_language.mutation_marker.as_str(),
         }
     }


### PR DESCRIPTION
## Summary
- Adds `Language::Lean` to the built-in language enum
- Maps name `lean` / extension `.lean` → `Language::Lean`
- Comment delimiters `/-` ... `-/` (Lean 4)
- Mutation marker `|` (same generic escape Rust uses)

## Why
etna-cli's experiment driver looks up the workload's `language` field via
`marauders::Language::name_to_language(&primary_lang, &custom_languages)`
where `custom_languages` is read **only** from a `marauder.toml` at the
experiment root (src/driver.rs:1032). Workloads can ship their own
`marauder.toml`, but it's ignored.

Without this PR, every Lean workload (e.g. https://github.com/alpaylan/cedar-etna)
forces users to manually \`cp workloads/<name>/marauder.toml .\` after
\`etna workload add\`, otherwise \`etna experiment run\` aborts with
\`language 'lean' is not known or supported\`.

With this PR, Lean is a first-class builtin alongside Rust/Haskell/Rocq/OCaml/Python/Racket.

## Test plan
- [x] \`cargo build --release\` succeeds
- [x] \`cargo test --release languages\` passes
- [ ] After merge, drop \`marauder.toml\` from cedar-etna and re-run
  \`etna experiment run\` end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 57e19972b2bf218c219e164457f91d0c378d4cd3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->