### PR TITLE
Extend comment grammar with Lean delimiters /- and -/

### DIFF
--- a/src/syntax/comment.pest
+++ b/src/syntax/comment.pest
@@ -40,10 +40,10 @@ tags = { "[" ~ WHITE_SPACE? ~ tag ~ (WHITE_SPACE? ~ "," ~ WHITE_SPACE? ~ tag)* ~
 // Tag ::= alphanumeric string, allowing hyphens and digits (e.g. "off-by-one", "issue-143")
 tag = @{ (ASCII_ALPHA | ASCII_DIGIT | "_") ~ (ASCII_ALPHA | ASCII_DIGIT | "_" | "-")* }
 
-comment_begin = { "(*" | "/*" | "{-" | "#|" | "//" | "\"\"\"" }
+comment_begin = { "(*" | "/*" | "{-" | "#|" | "/-" | "//" | "\"\"\"" }
 line_comment_end = @{ "//" ~ SINGLE_HSPACE* ~ &(NL | EOI) }
-comment_end   = { "*)" | "*/" | "-}" | "|#" | line_comment_end | "\"\"\"" }
-block_comment_end = { "*)" | "*/" | "-}" | "|#" | "\"\"\"" }
+comment_end   = { "*)" | "*/" | "-}" | "|#" | "-/" | line_comment_end | "\"\"\"" }
+block_comment_end = { "*)" | "*/" | "-}" | "|#" | "-/" | "\"\"\"" }
 
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHA | ASCII_DIGIT | "_")* }
 


### PR DESCRIPTION
Follow-up to #3 (which added Lean to the Language enum).

#3 made etna-cli accept \`language = \"lean\"\` workloads, which is
sufficient for **patch-based** workloads (e.g. cedar-etna): patches go
through marauders' patch-bundle path and bypass the comment grammar
entirely.

It does **not** make inline marauders syntax in .lean files work,
because the pest grammar (\`src/syntax/comment.pest\`) lists comment
delimiters as a hardcoded alternation that didn't include \`/-\` /
\`-/\`. \`marauders list\` on a .lean file with \`/-| my_mut -/\`
markers silently returns zero variations.

This PR adds \`/-\` to \`comment_begin\` and \`-/\` to \`comment_end\`
+ \`block_comment_end\`. Verified on a synthetic Lean file:

\`\`\`lean
def foo (x : Int) : Int :=
  /-| sign_bug -/
  if x > 0 then x else 0
  /-|| sign_bug_aaaaaaa_1 -/
  /-|
  if x ≥ 0 then x else 0
  -/
  /- |-/
\`\`\`

\`\`\`
$ marauders list
./test.lean:2 (name: sign_bug, active: base, variants: [\"sign_bug_aaaaaaa_1\"], tags: [])

$ marauders set --variant sign_bug_aaaaaaa_1
# active body now uses 'x ≥ 0' instead of 'x > 0'
\`\`\`

## Test plan
- [x] cargo build --release
- [x] marauders list / marauders set / marauders unset on inline .lean
- [x] cedar-etna patch flow still works (patches/ path is unaffected)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized grammar change that only broadens recognized comment delimiters; main risk is unintended parsing interactions if `/-`/`-/` appear in non-comment contexts.
> 
> **Overview**
> Enables inline marauders syntax in Lean source by extending `src/syntax/comment.pest` to treat `/-` as a valid `comment_begin` delimiter and `-/` as a valid `comment_end`/`block_comment_end` delimiter.
> 
> This allows variation/variant markers embedded in Lean block comments to be discovered and manipulated the same way as other supported languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00f30887e2ee45fe7840b1ba4fb7e3362fa8c4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->